### PR TITLE
feat(filters): Tag/Mention quick filter (P1-08)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ export default function Dashboard() {
   const [locFilter, setLocFilter] = useState('');
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
   const parsed = (posts as Post[]).map((p) => {
     if (isParseEnabled()) {
       return { id: p.id, ts: p.timestamp, ...parsePost(p) };
@@ -33,6 +34,13 @@ export default function Dashboard() {
     if (locFilter.trim()) {
       const q = locFilter.trim();
       rows = rows.filter((r) => r.where.join(' ').includes(q));
+    }
+    if (tagFilter.trim()) {
+      const q = tagFilter.trim();
+      rows = rows.filter((r) => {
+        const tags = [...r.which.mentions, ...r.which.hashtags];
+        return tags.some((t) => t.includes(q));
+      });
     }
     const from = fromDate ? new Date(fromDate) : null;
     const to = toDate ? new Date(toDate) : null;
@@ -63,6 +71,16 @@ export default function Dashboard() {
             placeholder="जैसे: रायगढ़"
             value={locFilter}
             onChange={(e) => setLocFilter(e.target.value)}
+          />
+        </label>
+        <label className="text-sm">
+          टैग/मेंशन फ़िल्टर
+          <input
+            aria-label="टैग/मेंशन फ़िल्टर"
+            className="ml-2 border px-2 py-1 rounded"
+            placeholder="#समारोह, @PMOIndia"
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
           />
         </label>
         <label className="text-sm">

--- a/tests/dashboard-tag-filter.test.tsx
+++ b/tests/dashboard-tag-filter.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import Dashboard from '@/components/Dashboard';
+
+describe('Dashboard tag/mention quick filter', () => {
+  it('filters by hashtag (e.g., #समारोह)', () => {
+    render(<Dashboard />);
+    const table = screen.getByRole('table', { name: 'गतिविधि सारणी' });
+    const tbody = within(table).getByTestId('tbody');
+
+    const baseline = within(tbody).getAllByRole('row').length;
+
+    const input = screen.getByLabelText('टैग/मेंशन फ़िल्टर');
+    fireEvent.change(input, { target: { value: '#समारोह' } });
+
+    const filtered = within(tbody).getAllByRole('row').length;
+    expect(filtered).toBeLessThan(baseline);
+
+    for (const row of within(tbody).getAllByRole('row')) {
+      const tagCell = within(row).getAllByRole('cell')[3];
+      expect(tagCell.textContent || '').toMatch(/#समारोह/);
+    }
+  });
+
+  it('filters by mention (e.g., @PMOIndia)', () => {
+    render(<Dashboard />);
+    const table = screen.getByRole('table', { name: 'गतिविधि सारणी' });
+    const tbody = within(table).getByTestId('tbody');
+
+    const baseline = within(tbody).getAllByRole('row').length;
+
+    const input = screen.getByLabelText('टैग/मेंशन फ़िल्टर');
+    fireEvent.change(input, { target: { value: '@PMOIndia' } });
+
+    const filtered = within(tbody).getAllByRole('row').length;
+    expect(filtered).toBeLessThan(baseline);
+
+    for (const row of within(tbody).getAllByRole('row')) {
+      const tagCell = within(row).getAllByRole('cell')[3];
+      expect(tagCell.textContent || '').toMatch(/@PMOIndia/);
+    }
+  });
+});
+


### PR DESCRIPTION
- Adds 'टैग/मेंशन फ़िल्टर' input to filter rows by hashtags or mentions (substring match)
- Adds unit tests in tests/dashboard-tag-filter.test.tsx
- Keeps a11y with proper labels; integrates alongside existing filters

Acceptance:
- All unit tests pass
- Coverage unchanged
