### PR TITLE
feat(ci): automate project board deployed column

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -41,3 +41,13 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      - name: Update Project Board - Deployed
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'prod')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+          PROJECT_OWNER: Pinak-Setu
+          PROJECT_NUMBER: "4"
+          ISSUE_LABEL: Task
+        run: |
+          echo "Production deployment completed - updating project board"
+          node scripts/move-to-deployed.js || echo "Project board update skipped (missing scopes or config)"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "e2e:smoke": "playwright test -c playwright.config.ts",
     "ci:monitor": "./scripts/ci-monitor.sh",
     "ci:status": "./scripts/ci-status-table.sh",
-    "deploy": "vercel --prod"
+    "deploy": "vercel --prod",
+    "project:deployed": "node scripts/update-project-board.js",
+    "project:move": "node scripts/move-to-deployed.js"
   },
   "dependencies": {
     "next": "^14.2.5",

--- a/scripts/move-to-deployed.js
+++ b/scripts/move-to-deployed.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/*
+ Moves closed Task issues into the "Deployed" status on a Projects (v2) board.
+
+ Requirements:
+ - Env GH_TOKEN with a token that has 'project' read/write scopes (classic) or equivalent fine-grained project write.
+ - Env PROJECT_OWNER (e.g. "Pinak-Setu")
+ - Env PROJECT_NUMBER (e.g. "4")
+ - Optional: ISSUE_LABEL (default: "Task")
+
+ This script intentionally keeps logic simple and idempotent:
+ - For each closed issue with the label, ensure it's added to the project
+ - Update the project's single-select Status field to "Deployed"
+*/
+
+const { execFileSync } = require('child_process');
+
+function runGh(args, input) {
+  const env = { ...process.env };
+  const result = execFileSync('gh', args, {
+    encoding: 'utf8',
+    input,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return result;
+}
+
+function ghGraphql(query, variables = {}) {
+  const args = ['api', 'graphql', '-f', `query=${query}`, '-f', `variables=${JSON.stringify(variables)}`];
+  const out = runGh(args);
+  return JSON.parse(out);
+}
+
+function ensureEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function getClosedTaskIssues(label) {
+  const fields = 'id,number,title,closedAt';
+  const args = ['issue', 'list', '--state', 'closed', '--label', label, '--json', fields];
+  const out = runGh(args);
+  return JSON.parse(out);
+}
+
+function getProject(owner, number) {
+  const q = `query($owner: String!, $number: Int!) {
+    user(login: $owner) {
+      projectV2(number: $number) {
+        id
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2SingleSelectField { id name options { id name } }
+          }
+        }
+      }
+    }
+  }`;
+  const data = ghGraphql(q, { owner, number: Number(number) });
+  if (!data.user || !data.user.projectV2) {
+    throw new Error('Project not found or token lacks read:project');
+  }
+  return data.user.projectV2;
+}
+
+function addIssueToProject(projectId, issueNodeId) {
+  const q = `mutation($projectId: ID!, $contentId: ID!) {
+    addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+      item { id }
+    }
+  }`;
+  try {
+    const res = ghGraphql(q, { projectId, contentId: issueNodeId });
+    return res.addProjectV2ItemById.item.id;
+  } catch (e) {
+    // If already exists, we'll fetch via node() lookup next
+    return null;
+  }
+}
+
+function getProjectItemIdForIssue(projectId, issueNodeId) {
+  const q = `query($issueId: ID!) {
+    node(id: $issueId) {
+      ... on Issue {
+        projectItems(first: 50) {
+          nodes { id project { id } }
+        }
+      }
+    }
+  }`;
+  const data = ghGraphql(q, { issueId: issueNodeId });
+  const items = data.node?.projectItems?.nodes || [];
+  const found = items.find((n) => n.project?.id === projectId);
+  return found?.id || null;
+}
+
+function updateStatus(projectId, itemId, fieldId, optionId) {
+  const q = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId,
+      itemId: $itemId,
+      fieldId: $fieldId,
+      value: { singleSelectOptionId: $optionId }
+    }) { projectV2Item { id } }
+  }`;
+  ghGraphql(q, { projectId, itemId, fieldId, optionId });
+}
+
+function main() {
+  // Validate env
+  ensureEnv('GH_TOKEN'); // ensure token present
+  const owner = ensureEnv('PROJECT_OWNER');
+  const number = ensureEnv('PROJECT_NUMBER');
+  const label = process.env.ISSUE_LABEL || 'Task';
+
+  console.log(`Synchronizing closed '${label}' issues to 'Deployed' on ${owner}/projects/${number} ...`);
+
+  // Discover project + Status field + "Deployed" option
+  const project = getProject(owner, number);
+  const projectId = project.id;
+  const statusField = (project.fields.nodes || []).find((f) => f && f.name === 'Status');
+  if (!statusField) {
+    throw new Error('Status field not found on project. Please add a single-select field named "Status".');
+  }
+  const deployedOption = (statusField.options || []).find((o) => o.name === 'Deployed');
+  if (!deployedOption) {
+    throw new Error('"Deployed" option not found in Status field. Please add it to the project.');
+  }
+
+  const issues = getClosedTaskIssues(label);
+  if (!issues.length) {
+    console.log('No closed issues found. Nothing to do.');
+    return;
+  }
+
+  let moved = 0;
+  for (const issue of issues) {
+    const issueNodeId = issue.id; // GraphQL node id
+    // Ensure the issue is an item on the project
+    let itemId = addIssueToProject(projectId, issueNodeId);
+    if (!itemId) {
+      itemId = getProjectItemIdForIssue(projectId, issueNodeId);
+    }
+    if (!itemId) {
+      console.warn(`Could not determine project item for issue #${issue.number}`);
+      continue;
+    }
+    // Update its Status to Deployed
+    updateStatus(projectId, itemId, statusField.id, deployedOption.id);
+    console.log(`Moved #${issue.number} → Deployed`);
+    moved += 1;
+  }
+
+  console.log(`Done. Updated ${moved} issues.`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('Failed to update project board:', err?.message || err);
+  process.exit(1);
+}
+
+

--- a/scripts/update-project-board.js
+++ b/scripts/update-project-board.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+// Get all closed issues with Task label
+const closedIssues = JSON.parse(execSync('gh issue list --state closed --label "Task" --json number,title,closedAt', { encoding: 'utf8' }));
+
+console.log('📋 Closed Task Issues Ready for Deployed Column:');
+console.log('='.repeat(60));
+
+closedIssues.forEach(issue => {
+  const closedDate = new Date(issue.closedAt);
+  const daysSinceClosed = Math.floor((new Date() - closedDate) / (1000 * 60 * 60 * 24));
+
+  console.log(`✅ Issue #${issue.number}: ${issue.title}`);
+  console.log(`   Closed: ${closedDate.toISOString().split('T')[0]} (${daysSinceClosed} days ago)`);
+  console.log(`   Status: Ready for Deployed column`);
+  console.log('');
+});
+
+console.log(`🎯 Total closed tasks: ${closedIssues.length}`);
+console.log('');
+console.log('💡 To move these to Deployed column:');
+console.log('   1. Go to https://github.com/users/Pinak-Setu/projects/4');
+console.log('   2. Drag each closed issue to the "Deployed" column');
+console.log('   3. Or use GitHub CLI: gh issue edit <number> --add-project "Project Board" --column "Deployed"');


### PR DESCRIPTION
This PR introduces automation to move completed tasks to the 'Deployed' column on the project board after a successful production deployment.

- Adds 'scripts/move-to-deployed.js' to update the project board via GitHub API.
- Updates the Vercel deployment workflow to trigger this script.
- Requires the 'GH_PROJECT_TOKEN' secret with project read/write permissions.
- Also includes previous commits for project board management and TODO list synchronization.